### PR TITLE
doc: msmtp: Add missing 'user' directive

### DIFF
--- a/doc/example-msmtp.conf
+++ b/doc/example-msmtp.conf
@@ -14,5 +14,6 @@ account default
 host smtp.office365.com
 port 587
 auth xoauth2
+user user@domain
 from user@domain
 passwordeval cms-oauth --cms_sock=cms.sock --proto=SMTP --user=user@domain --output=token


### PR DESCRIPTION
A 'user' directive is needed otherwise msmtp fails:
msmtp: authentication method XOAUTH2 needs a user name
msmtp: could not send mail (account default from .msmtprc)

Fixes: 8f7c714265c7 ("Add cms-oauth")
Signed-off-by: Benjamin Poirier <bpoirier@nvidia.com>