### PR TITLE
Set of commits to simplify flows for emacs users

### DIFF
--- a/cloud_mdir_sync/cms_oauth_main.py
+++ b/cloud_mdir_sync/cms_oauth_main.py
@@ -75,6 +75,10 @@ def main():
         actual final value to send on the wire in the XOAUTH2 protocol.
         xoauth2 is used if the caller will provide the base64 conversion.
         token returns the bare access_token""")
+    parser.add_argument(
+        "--no_newline",
+        action="store_true",
+        help="""Disable printing an additional newline in the output.""")
 
     tests = parser.add_mutually_exclusive_group()
     tests.add_argument(
@@ -95,6 +99,10 @@ def main():
         and imap.gmail.com.""")
     args = parser.parse_args()
 
+    print_end = "\n"
+    if args.no_newline:
+        print_end = ""
+
     xoauth2_token = get_xoauth2_token(args)
     if args.test_smtp:
         return test_smtp(args, xoauth2_token)
@@ -102,12 +110,12 @@ def main():
         return test_imap(args, xoauth2_token)
 
     if args.output == "xoauth2-b64":
-        print(base64.b64encode(xoauth2_token.encode()).decode())
+        print(base64.b64encode(xoauth2_token.encode()).decode(), end=print_end)
     elif args.output == "token":
         g = re.match("user=\\S+\1auth=\\S+ (\\S+)\1\1", xoauth2_token)
-        print(g.group(1))
+        print(g.group(1), end=print_end)
     else:
-        print(xoauth2_token)
+        print(xoauth2_token, end=print_end)
 
 
 if __name__ == "__main__":

--- a/doc/imap.md
+++ b/doc/imap.md
@@ -52,3 +52,23 @@ set imap_authenticators="xoauth2"
 set imap_oauth_refresh_command="cms-oauth --cms_sock=cms.sock --proto=IMAP --user user@domain --output=token"
 set spoolfile="imaps://outlook.office365.com/INBOX"
 ```
+
+# isync / mbsync
+
+`mbsync` can support XOAUTH2 with the Cyrus SASL OAuth2 plugin. Here is an
+example configuration excerpt, assuming `mbsync` has been correctly installed
+with the plugin.
+
+```
+IMAPAccount accountname
+# Address to connect to
+Host imap.server.address
+Port 993
+User user@domain.com
+# Using cloud-mdir-sync to manage OAuth2 bearer token
+PassCmd "cms-oauth --cms_sock=/var/run/user/XXX/cms.sock --proto=IMAP --user user@domain.com --output=token"
+AuthMechs XOAUTH2
+# Use SSL
+SSLType IMAPS
+CertificateFile /etc/ssl/certs/ca-certificates.crt
+```


### PR DESCRIPTION
* smtpmail's xoauth2 implementation is sensitive to newlines in the token output
* Document how to configure smtpmail with cms-oauth
* Document how to configure isync/mbsync with cms-oauth (which is commonly used with `mu4e`)