### PR TITLE
use watchdog instead of pyinotify for cross-platform compatability

### DIFF
--- a/cloud_mdir_sync/config.py
+++ b/cloud_mdir_sync/config.py
@@ -5,7 +5,8 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, Dict, List
 
-import pyinotify
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 if TYPE_CHECKING:
     from . import messages, mailbox, oauth
@@ -20,7 +21,7 @@ class Config(object):
     web_app: "oauth.WebServer"
     logger: logging.Logger
     loop: asyncio.AbstractEventLoop
-    watch_manager: pyinotify.WatchManager
+    observer: Observer
     msgdb: "messages.MessageDB"
     cloud_mboxes: "List[mailbox.Mailbox]"
     local_mboxes: "List[mailbox.Mailbox]"
@@ -44,6 +45,7 @@ class Config(object):
         self.async_tasks = []
         self.message_db_dir = os.path.expanduser(self.message_db_dir)
         self.direct_message = self._direct_message
+        self.observer = Observer()  # Use watchdog observer
 
     def load_config(self, fn):
         """The configuration file is a python script that we execute with
@@ -62,7 +64,7 @@ class Config(object):
     def storage_key(self):
         """The storage key is used with fernet to manage the authentication
         data, which is stored to disk using symmetric encryption. The
-        decryption key is keld by the system keyring in some secure storage.
+        decryption key is held by the system keyring in some secure storage.
         On Linux desktop systems this is likely to be something like
         gnome-keyring."""
         import keyring
@@ -136,3 +138,4 @@ class Config(object):
 
     def _direct_message(self, msg):
         return self.local_mboxes[0]
+

--- a/cloud_mdir_sync/maildir.py
+++ b/cloud_mdir_sync/maildir.py
@@ -5,15 +5,23 @@ import pickle
 import re
 import time
 
-import pyinotify
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 from . import config, mailbox, messages, util
-
 
 def unfold_header(s):
     # Hrm, I wonder if this is the right way to normalize a header?
     return re.sub(r"\n[ \t]+", " ", s)
 
+class MailDirEventHandler(FileSystemEventHandler):
+    def __init__(self, mailbox):
+        self.mailbox = mailbox
+
+    def on_any_event(self, event):
+        if event.event_type in ['modified', 'moved', 'created', 'deleted']:
+            self.mailbox.need_update = True
+            self.mailbox.changed_event.set()
 
 class MailDirMailbox(mailbox.Mailbox):
     """Local MailDir mail directory"""
@@ -31,17 +39,16 @@ class MailDirMailbox(mailbox.Mailbox):
             os.makedirs(os.path.join(self.dfn, sub), mode=0o700, exist_ok=True)
 
     async def setup_mbox(self):
-        self.cfg.watch_manager.add_watch(
-            path=[
-                os.path.join(self.dfn, "cur"),
-                os.path.join(self.dfn, "new")
-            ],
-            proc_fun=self._dir_changed,
-            mask=(pyinotify.IN_ATTRIB | pyinotify.IN_MOVED_FROM
-                  | pyinotify.IN_MOVED_TO
-                  | pyinotify.IN_CREATE | pyinotify.IN_DELETE
-                  | pyinotify.IN_ONLYDIR),
-            quiet=False)
+        self._observer = Observer()
+        self._event_handler = MailDirEventHandler(self)
+
+        dirs_to_watch = [
+          os.path.join(self.dfn, "cur"),
+          os.path.join(self.dfn, "new")
+        ]
+
+        for directory in dirs_to_watch:
+          self._observer.schedule(self._event_handler, directory, recursive=False)
 
     def _dir_changed(self, notifier):
         self.need_update = True


### PR DESCRIPTION
This commit contains code that replaces `pyinoitfy` with `watchdog`. The benefits are: 1) cross-platform compatibility: the code seems to work on Macbook now. 2) compatibility with newer version of python (3.12), which has removed pyinotify.