### PR TITLE
Watchdog

### DIFF
--- a/cloud_mdir_sync/config.py
+++ b/cloud_mdir_sync/config.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, Dict, List
 
-import pyinotify
+from watchdog.observers import Observer
 
 if TYPE_CHECKING:
     from . import messages, mailbox, oauth
@@ -20,7 +20,7 @@ class Config(object):
     web_app: "oauth.WebServer"
     logger: logging.Logger
     loop: asyncio.AbstractEventLoop
-    watch_manager: pyinotify.WatchManager
+    observer: Observer
     msgdb: "messages.MessageDB"
     cloud_mboxes: "List[mailbox.Mailbox]"
     local_mboxes: "List[mailbox.Mailbox]"
@@ -44,6 +44,7 @@ class Config(object):
         self.async_tasks = []
         self.message_db_dir = os.path.expanduser(self.message_db_dir)
         self.direct_message = self._direct_message
+        self.observer = Observer()
 
     def load_config(self, fn):
         """The configuration file is a python script that we execute with

--- a/cloud_mdir_sync/maildir.py
+++ b/cloud_mdir_sync/maildir.py
@@ -5,7 +5,8 @@ import pickle
 import re
 import time
 
-import pyinotify
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 from . import config, mailbox, messages, util
 
@@ -14,6 +15,14 @@ def unfold_header(s):
     # Hrm, I wonder if this is the right way to normalize a header?
     return re.sub(r"\n[ \t]+", " ", s)
 
+class MailDirEventHandler(FileSystemEventHandler):
+    def __init__(self, mailbox):
+        self.mailbox = mailbox
+
+    def on_any_event(self, event):
+        if event.event_type in ['modified', 'moved', 'created', 'deleted']:
+            self.mailbox.need_update = True
+            self.mailbox.changed_event.set()
 
 class MailDirMailbox(mailbox.Mailbox):
     """Local MailDir mail directory"""
@@ -31,18 +40,15 @@ class MailDirMailbox(mailbox.Mailbox):
             os.makedirs(os.path.join(self.dfn, sub), mode=0o700, exist_ok=True)
 
     async def setup_mbox(self):
-        self.cfg.watch_manager.add_watch(
-            path=[
-                os.path.join(self.dfn, "cur"),
-                os.path.join(self.dfn, "new")
-            ],
-            proc_fun=self._dir_changed,
-            mask=(pyinotify.IN_ATTRIB | pyinotify.IN_MOVED_FROM
-                  | pyinotify.IN_MOVED_TO
-                  | pyinotify.IN_CREATE | pyinotify.IN_DELETE
-                  | pyinotify.IN_ONLYDIR),
-            quiet=False)
+        self._event_handler = MailDirEventHandler(self)
 
+        dirs_to_watch = [
+          os.path.join(self.dfn, "cur"),
+          os.path.join(self.dfn, "new")
+        ]
+
+        for directory in dirs_to_watch:
+          self.cfg.observer.schedule(self._event_handler, directory, recursive=False)
     def _dir_changed(self, notifier):
         self.need_update = True
         self.changed_event.set()

--- a/cloud_mdir_sync/main.py
+++ b/cloud_mdir_sync/main.py
@@ -135,8 +135,11 @@ def main():
     try:
         cfg.loop.run_until_complete(synchronize_mail(cfg))
     finally:
+        for task in asyncio.all_tasks(cfg.loop):
+          task.cancel()
         cfg.loop.run_until_complete(cfg.loop.shutdown_asyncgens())
         cfg.observer.stop()
+        cfg.observer.join()
         cfg.msgdb.close()
         cfg.loop.close()
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'keyring>=21',
         'oauthlib>=3.1',
         'pyasyncore',
-        'pyinotify>=0.9.6',
+        'watchdog',
     ],
     include_package_data=True,
     zip_safe=False)


### PR DESCRIPTION
Use `watchdog` instead of `pyinotify` for maildir changes monitoring. The benefit is that the program can be used in other platforms.