### PR TITLE
office365: Support custom Microsoft Entra Id application registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ MailDir("~/mail/INBOX")
 Office365("inbox", Office365_Account(user="user@domain.com", tenant="<MSFT tenant id>", client_id="<MSFT app client id>"))
 ```
 
+and if you have a built-in work configuration in `cloud_mdir_sync` but want to
+use the common registration
+
+```Python
+MailDir("~/mail/INBOX")
+Office365("inbox", Office365_Account(user="user@domain.com", use_default_registration=True))
+```
+
 or with Gmail:
 
 ```Python

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ MailDir("~/mail/INBOX")
 Office365("inbox", Office365_Account(user="user@domain.com"))
 ```
 
+and in case your work configuration requires you to use your specific tenant to
+register `cloud_mdir_sync`
+
+```Python
+MailDir("~/mail/INBOX")
+Office365("inbox", Office365_Account(user="user@domain.com", tenant="<MSFT tenant id>", client_id="<MSFT app client id>"))
+```
+
 or with Gmail:
 
 ```Python

--- a/cloud_mdir_sync/config.py
+++ b/cloud_mdir_sync/config.py
@@ -82,13 +82,13 @@ class Config(object):
     def all_mboxes(self):
         return itertools.chain(self.local_mboxes, self.cloud_mboxes)
 
-    def Office365_Account(self, user=None, tenant="common"):
+    def Office365_Account(self, user=None, tenant="common", client_id="122f4826-adf9-465d-8e84-e9d00bc9f234"):
         """Define an Office365 account credential. If user is left as None
         then the browser will prompt for the user and the choice will be
         cached. To lock the account to a single tenant specify the Azure
         Directory name, ie 'contoso.onmicrosoft.com', or the GUID."""
         from .office365 import GraphAPI
-        self.async_tasks.append(GraphAPI(self, user, tenant))
+        self.async_tasks.append(GraphAPI(self, user, tenant, client_id))
         return self.async_tasks[-1]
 
     def Office365(self, mailbox, account):

--- a/cloud_mdir_sync/config.py
+++ b/cloud_mdir_sync/config.py
@@ -82,11 +82,15 @@ class Config(object):
     def all_mboxes(self):
         return itertools.chain(self.local_mboxes, self.cloud_mboxes)
 
-    def Office365_Account(self, user=None, tenant="common", client_id="122f4826-adf9-465d-8e84-e9d00bc9f234"):
+    def Office365_Account(self, user=None, tenant=None, client_id=None, use_default_registration=False):
         """Define an Office365 account credential. If user is left as None
         then the browser will prompt for the user and the choice will be
         cached. To lock the account to a single tenant specify the Azure
         Directory name, ie 'contoso.onmicrosoft.com', or the GUID."""
+        if tenant is None or client_id is None:
+            from .office365 import AppRegistration
+            app_registration = AppRegistration(user, use_default_registration)
+            tenant, client_id = app_registration.get()
         from .office365 import GraphAPI
         self.async_tasks.append(GraphAPI(self, user, tenant, client_id))
         return self.async_tasks[-1]

--- a/cloud_mdir_sync/oauth.py
+++ b/cloud_mdir_sync/oauth.py
@@ -192,6 +192,7 @@ class OAuth2Session(object):
                 data=dict(oauthlib.common.urldecode(body)),
                 headers={
                     "Accept": "application/json",
+                    "Origin": "http://127.0.0.1:8080/",
                     #"Content-Type":
                     #"application/x-www-form-urlencoded;charset=UTF-8",
                 }) as op:
@@ -215,6 +216,7 @@ class OAuth2Session(object):
                 data=dict(oauthlib.common.urldecode(body)),
                 headers={
                     "Accept": "application/json",
+                    "Origin": "http://127.0.0.1:8080/",
                     #"Content-Type":
                     #"application/x-www-form-urlencoded;charset=UTF-8",
                 }) as op:

--- a/cloud_mdir_sync/office365.py
+++ b/cloud_mdir_sync/office365.py
@@ -81,15 +81,15 @@ def _retry_protect(func):
 
 class GraphAPI(oauth.Account):
     """An OAUTH2 authenticated session to the Microsoft Graph API"""
-    client_id = "122f4826-adf9-465d-8e84-e9d00bc9f234"
     graph_token: Optional[Dict[str,str]] = None
     owa_token: Optional[Dict[str,str]] = None
     authenticator = None
 
-    def __init__(self, cfg: config.Config, user: str, tenant: str):
+    def __init__(self, cfg: config.Config, user: str, tenant: str, client_id: str):
         super().__init__(cfg, user)
         self.domain_id = f"o365-{user}-{tenant}"
         self.tenant = tenant
+        self.client_id = client_id
 
         if self.user is not None:
             self.name = f"{self.user}//{tenant}"

--- a/cloud_mdir_sync/office365.py
+++ b/cloud_mdir_sync/office365.py
@@ -79,6 +79,39 @@ def _retry_protect(func):
     return async_wrapper
 
 
+class AppRegistration():
+    registration_lookup: Dict[str,Dict[str,str]] = {
+        "nvidia.com": {
+            "tenant": "43083d15-7273-40c1-b7db-39efd9ccc17a",
+            "client_id": "472bb794-a546-4311-96f9-76bc79989214",
+        },
+    }
+    default_registration: Dict[str,str] = {
+        "tenant": "common",
+        "client_id": "122f4826-adf9-465d-8e84-e9d00bc9f234",
+    }
+
+    def __init__(self, user: str, use_default_registration: bool):
+        self.use_default_registration = use_default_registration
+        user_split = user.split("@")
+        if len(user_split) < 2:
+            self.use_default_registration = True
+        else:
+            self.domain = user_split[1]
+
+    def get(self) -> tuple[str,str]:
+        default_tenant = self.default_registration["tenant"]
+        default_client_id = self.default_registration["client_id"]
+
+        if self.use_default_registration:
+            return (default_tenant, default_client_id)
+
+        registration = self.registration_lookup.get(self.domain)
+        if registration is None:
+            return (default_tenant, default_client_id)
+
+        return (registration["tenant"], registration["client_id"])
+
 class GraphAPI(oauth.Account):
     """An OAUTH2 authenticated session to the Microsoft Graph API"""
     graph_token: Optional[Dict[str,str]] = None


### PR DESCRIPTION
Some Microsoft tenants might be configured with a strict posture that does not make using applications external to that tenant trivial. Consume a tenant id and client id from a user's registered Microsoft Entra Id application if provided through a user's configuration.