### PR TITLE
Support standard collection type hinting generics in python<3.9

### DIFF
--- a/cloud_mdir_sync/office365.py
+++ b/cloud_mdir_sync/office365.py
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0+
+
+# Bring standard collection type hinting generics to python<3.9
+from __future__ import annotations
+
 import asyncio
 import datetime
 import functools


### PR DESCRIPTION
Python 3.7 and above offer a pathway to avoid depending on specialized type hinting annotations for collections that were deprecated in python 3.9. Import the annotation support from __future__ to keep the program compatible with python>=3.7.

Fixes: fba1436c914c ("office365: Add a AppRegistration lookup class for different tenants")